### PR TITLE
chore(cache-control): stale while revalidate

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,7 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "public, max-age=31536000, no-cache"
+            "value": "public, max-age=1, must-revalidate, stale-while-revalidate=604800, stale-if-error=604800"
           }
         ]
       },


### PR DESCRIPTION
Allow stale content to be served while revalidating in the background.