### PR TITLE
fix(shoppinglist): rename group header items to group items

### DIFF
--- a/pages/shoppinglist.vue
+++ b/pages/shoppinglist.vue
@@ -29,7 +29,7 @@
             />
           </template>
 
-          <template #[`group.header`]="{ group, groupItems }">
+          <template #[`group.header`]="{ group, items: groupItems }">
             <td :colspan="headers.length" class="item handle">
               <v-container class="pa-0">
                 <v-row>


### PR DESCRIPTION
The groupItems were undefined since I was not renaming the destruct properly.

resolves #1669